### PR TITLE
Fixing a bug with null values in arrays

### DIFF
--- a/src/Vnn/Keyper/Keyper.php
+++ b/src/Vnn/Keyper/Keyper.php
@@ -85,7 +85,6 @@ class Keyper
      */
     protected function getArgs($key, &$values = [])
     {
-
         if (is_array($key)) {
             foreach ($key as $k) {
                 $this->getArgs($k, $values);
@@ -93,7 +92,7 @@ class Keyper
             return $values;
         }
 
-        if (isset($this->array[$key])) {
+        if (array_key_exists($key, $this->array)) {
             $values[] = $this->array[$key];
         }
 

--- a/test/Vnn/Keyper/KeyperTest.php
+++ b/test/Vnn/Keyper/KeyperTest.php
@@ -29,7 +29,8 @@ class KeyperTest extends PHPUnit_Framework_TestCase
         'key3.nested' => 'fakeout',
         'key3' => [
             'nested' => 'value'
-        ]
+        ],
+        'key99' => null
     ];
 
     public function test_callable_executes_when_array_key_exists()
@@ -163,5 +164,15 @@ class KeyperTest extends PHPUnit_Framework_TestCase
     {
         $keyper = Keyper::create($this->data);
         $this->assertEquals(5, $keyper->get('nested.three.four'));
+    }
+
+    public function test_when_works_with_null_values()
+    {
+        $keyper = Keyper::create($this->data);
+        $called = false;
+        $keyper->when('key99', function () use (&$called) {
+            $called = true;
+        });
+        $this->assertFalse($called);
     }
 }


### PR DESCRIPTION
isset() was used to check if a key is present in an array, but if the
value is null, this check will fail. Switched to array_key_exists().
